### PR TITLE
Add vertical-pod-autoscaler Helm chart

### DIFF
--- a/apps/controllers/vertical-pod-autoscaler/helmrelease.yaml
+++ b/apps/controllers/vertical-pod-autoscaler/helmrelease.yaml
@@ -1,0 +1,16 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vertical-pod-autoscaler
+  namespace: vpa
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: ./vertical-pod-autoscaler/charts/vertical-pod-autoscaler
+      sourceRef:
+        kind: GitRepository
+        name: vertical-pod-autoscaler
+        namespace: flux-system
+  values:
+    installCRDs: true

--- a/apps/controllers/vertical-pod-autoscaler/helmrepository.yaml
+++ b/apps/controllers/vertical-pod-autoscaler/helmrepository.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: vertical-pod-autoscaler
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://github.com/kubernetes/autoscaler
+  ref:
+    branch: master

--- a/apps/controllers/vertical-pod-autoscaler/kustomization.yaml
+++ b/apps/controllers/vertical-pod-autoscaler/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/apps/controllers/vertical-pod-autoscaler/namespace.yaml
+++ b/apps/controllers/vertical-pod-autoscaler/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vpa
+  labels:
+    name: vpa


### PR DESCRIPTION
Install vertical-pod-autoscaler using the official Helm chart from kubernetes/autoscaler repository via Flux GitRepository source.